### PR TITLE
Revert "wifi: Scan for networks every time the supplicant state changes"

### DIFF
--- a/service/java/com/android/server/wifi/WifiStateMachine.java
+++ b/service/java/com/android/server/wifi/WifiStateMachine.java
@@ -6366,9 +6366,6 @@ public class WifiStateMachine extends StateMachine implements WifiNative.WifiPno
                 default:
                     return NOT_HANDLED;
             }
-
-            log("EON: Doing WiFi scan due to SupplicantStartedState state change");
-            startScan(ENABLE_WIFI, 0, null, null);
             return HANDLED;
         }
 


### PR DESCRIPTION
This reverts commit a8fbd074. The commit acts as described, performing a full WiFi scan every time there is a SupplicantStartedState change. Unfortunately, one of those state changes is ["just finished a scan"](https://github.com/jyoung8607/android_frameworks_opt_net_wifi/blob/95f602575dc466aa078aed842e00edcba985d659/service/java/com/android/server/wifi/WifiStateMachine.java#L6280), so it loops performing active scans forever. The beginning of each active scan can be seen immediately in "logcat", it happens every five seconds.

![2019-11-03_17-58-46](https://user-images.githubusercontent.com/46612682/68159187-4d739400-ff1f-11e9-8c8e-d61ecdeca47d.png)

The continuous scanning will make EON chew through battery much faster than it needs to, and I think it may be impairing WiFi throughput. When the WiFi adapter is asked to scan for networks, those can be on other channels and bands, and it has to multitask by briefly pausing normal transmit/receive activity when it goes off-channel. I tried to perform a comparative throughput test, but I would have to backrev NEOS to earlier than v8 and my EON doesn't seem to want to go there.

The stated purpose of a8fbd074 is to make EON connect to local WiFi faster after booting up. If that's still a problem, deep in the Android framework is not the correct place to fix it. As an example, we could give it a one-time startup nudge from something application-level, perhaps in manager.py.